### PR TITLE
feat: implement Explore page with search, filters, and project grid

### DIFF
--- a/src/app/[locale]/(main)/explore/page.tsx
+++ b/src/app/[locale]/(main)/explore/page.tsx
@@ -1,3 +1,5 @@
+import ExploreFeature from '@/features/explore'
+
 export default function ExplorePage() {
-  return <div>ExplorePage</div>
+  return <ExploreFeature />
 }

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -21,6 +21,9 @@ export const ROUTES = {
     },
     PROTECTED: {
       EXPLORE: '/explore',
+      MY_PROJECTS: '/my-projects',
+      PROJECT_DETAIL: (id: number) => `/projects/${id}`,
+      PROFILE: (id: number) => `/profile/${id}`,
     },
   },
   API: {
@@ -40,6 +43,11 @@ export const ROUTES = {
       PROJECTS: {
         BASE: '/projects',
         SEARCH: '/projects/search',
+        BY_ID: (id: number) => `/projects/${id}`,
+        LIKE: (id: number) => `/projects/${id}/like`,
+        SAVE: (id: number) => `/projects/${id}/save`,
+        UNSAVE: (id: number) => `/projects/${id}/unsave`,
+        JOIN_REQUESTS: (id: number) => `/projects/${id}/join-requests`,
       },
     },
   },

--- a/src/features/explore/api/projectsApi.ts
+++ b/src/features/explore/api/projectsApi.ts
@@ -1,0 +1,20 @@
+import { SearchProject, SearchProjectResponse } from '@think-storm/contracts'
+import { api } from '@/lib/api/fetcher'
+import { ROUTES } from '@/constants/routes'
+
+export function searchProjects(params: SearchProject): Promise<SearchProjectResponse> {
+  const searchParams = new URLSearchParams()
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      searchParams.set(key, String(value))
+    }
+  })
+
+  const query = searchParams.toString()
+  const url = query
+    ? `${ROUTES.API.PROTECTED.PROJECTS.SEARCH}?${query}`
+    : ROUTES.API.PROTECTED.PROJECTS.SEARCH
+
+  return api.get<SearchProjectResponse>(url)
+}

--- a/src/features/explore/components/FilterPanel.tsx
+++ b/src/features/explore/components/FilterPanel.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { ProjectStatus, Goal } from '@think-storm/contracts'
+
+interface FilterPanelProps {
+  status: ProjectStatus | ''
+  goal: Goal | ''
+  onStatusChange: (status: ProjectStatus | '') => void
+  onGoalChange: (goal: Goal | '') => void
+  onReset: () => void
+}
+
+const statusOptions: { label: string; value: ProjectStatus | '' }[] = [
+  { label: 'All Statuses', value: '' },
+  { label: 'In Progress', value: ProjectStatus.InProgress },
+  { label: 'Complete', value: ProjectStatus.Complete },
+  { label: 'On Hold', value: ProjectStatus.OnHold },
+  { label: 'Canceled', value: ProjectStatus.Canceled },
+]
+
+const goalOptions: { label: string; value: Goal | '' }[] = [
+  { label: 'All Goals', value: '' },
+  { label: 'Education', value: Goal.Education },
+  { label: 'Open Source', value: Goal.OpenSource },
+  { label: 'Profitable', value: Goal.Profitable },
+  { label: 'Fun', value: Goal.Fun },
+]
+
+export default function FilterPanel({
+  status,
+  goal,
+  onStatusChange,
+  onGoalChange,
+  onReset,
+}: FilterPanelProps) {
+  const hasActiveFilters = status !== '' || goal !== ''
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <select
+        value={status}
+        onChange={(e) => onStatusChange(e.target.value as ProjectStatus | '')}
+        className="text-sm border border-gray-300 rounded-lg px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 bg-white text-gray-700"
+      >
+        {statusOptions.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      <select
+        value={goal}
+        onChange={(e) => onGoalChange(e.target.value as Goal | '')}
+        className="text-sm border border-gray-300 rounded-lg px-3 py-2.5 focus:outline-none focus:ring-2 focus:ring-indigo-500 bg-white text-gray-700"
+      >
+        {goalOptions.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      {hasActiveFilters && (
+        <button
+          type="button"
+          onClick={onReset}
+          className="text-sm text-indigo-600 hover:text-indigo-800 font-medium hover:underline underline-offset-2 transition-colors px-1"
+        >
+          Reset filters
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/features/explore/components/ProjectCard.tsx
+++ b/src/features/explore/components/ProjectCard.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { ProjectResponse, ProjectStatus, Goal } from '@think-storm/contracts'
+import { Users, Calendar, Globe } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const statusStyles: Record<ProjectStatus, string> = {
+  [ProjectStatus.Complete]: 'bg-green-100 text-green-700',
+  [ProjectStatus.InProgress]: 'bg-blue-100 text-blue-700',
+  [ProjectStatus.OnHold]: 'bg-yellow-100 text-yellow-700',
+  [ProjectStatus.Canceled]: 'bg-red-100 text-red-700',
+}
+
+const goalStyles: Record<Goal, string> = {
+  [Goal.Education]: 'bg-purple-100 text-purple-700',
+  [Goal.Profitable]: 'bg-emerald-100 text-emerald-700',
+  [Goal.Fun]: 'bg-orange-100 text-orange-700',
+  [Goal.OpenSource]: 'bg-cyan-100 text-cyan-700',
+}
+
+const statusLabel: Record<ProjectStatus, string> = {
+  [ProjectStatus.Complete]: 'Complete',
+  [ProjectStatus.InProgress]: 'In Progress',
+  [ProjectStatus.OnHold]: 'On Hold',
+  [ProjectStatus.Canceled]: 'Canceled',
+}
+
+interface ProjectCardProps {
+  project: ProjectResponse
+}
+
+export default function ProjectCard({ project }: ProjectCardProps) {
+  const formattedDate = new Date(project.createdAt).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+
+  const visibleDomainLabels = project.domainLabels?.slice(0, 2) ?? []
+  const visibleTechLabels = project.technicalLabels?.slice(0, 3) ?? []
+  const extraDomain = (project.domainLabels?.length ?? 0) - visibleDomainLabels.length
+  const extraTech = (project.technicalLabels?.length ?? 0) - visibleTechLabels.length
+
+  return (
+    <div className="group bg-white border border-gray-200 rounded-xl p-5 flex flex-col gap-3 hover:shadow-md hover:border-indigo-200 transition-all cursor-pointer">
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="text-base font-semibold text-gray-900 line-clamp-2 group-hover:text-indigo-700 transition-colors">
+          {project.title}
+        </h3>
+        <span
+          className={cn(
+            'text-xs px-2 py-0.5 rounded-full font-medium flex-shrink-0',
+            statusStyles[project.status],
+          )}
+        >
+          {statusLabel[project.status]}
+        </span>
+      </div>
+
+      {project.description && (
+        <p className="text-sm text-gray-600 line-clamp-2">{project.description}</p>
+      )}
+
+      <div className="flex flex-wrap gap-1.5">
+        <span className={cn('text-xs px-2 py-0.5 rounded-full font-medium', goalStyles[project.goal])}>
+          {project.goal}
+        </span>
+        {visibleDomainLabels.map((label) => (
+          <span key={label} className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">
+            {label}
+          </span>
+        ))}
+        {visibleTechLabels.map((label) => (
+          <span key={label} className="text-xs px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-600">
+            {label}
+          </span>
+        ))}
+        {(extraDomain > 0 || extraTech > 0) && (
+          <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">
+            +{extraDomain + extraTech} more
+          </span>
+        )}
+      </div>
+
+      <div className="mt-auto pt-3 border-t border-gray-100 flex items-center justify-between text-xs text-gray-500">
+        <div className="flex items-center gap-3">
+          <span className="flex items-center gap-1">
+            <Users className="w-3.5 h-3.5" />
+            {project.users.length} member{project.users.length !== 1 ? 's' : ''}
+          </span>
+          <span className="flex items-center gap-1">
+            <Globe className="w-3.5 h-3.5" />
+            {project.languageName}
+          </span>
+        </div>
+        <span className="flex items-center gap-1">
+          <Calendar className="w-3.5 h-3.5" />
+          {formattedDate}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/features/explore/components/ProjectGrid.tsx
+++ b/src/features/explore/components/ProjectGrid.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { ProjectResponse } from '@think-storm/contracts'
+import { ChevronLeft, ChevronRight, Frown } from 'lucide-react'
+import ProjectCard from './ProjectCard'
+
+interface ProjectGridProps {
+  projects: ProjectResponse[]
+  page: number
+  totalPages: number
+  totalItems: number
+  onPageChange: (page: number) => void
+  isLoading: boolean
+}
+
+function SkeletonCard() {
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl p-5 flex flex-col gap-3 animate-pulse">
+      <div className="flex justify-between gap-2">
+        <div className="h-5 bg-gray-200 rounded w-3/4" />
+        <div className="h-5 bg-gray-200 rounded w-16 flex-shrink-0" />
+      </div>
+      <div className="space-y-1.5">
+        <div className="h-3 bg-gray-100 rounded w-full" />
+        <div className="h-3 bg-gray-100 rounded w-5/6" />
+      </div>
+      <div className="flex gap-1.5">
+        <div className="h-5 bg-gray-100 rounded-full w-16" />
+        <div className="h-5 bg-gray-100 rounded-full w-20" />
+        <div className="h-5 bg-gray-100 rounded-full w-14" />
+      </div>
+      <div className="mt-auto pt-3 border-t border-gray-100 flex justify-between">
+        <div className="h-3 bg-gray-100 rounded w-24" />
+        <div className="h-3 bg-gray-100 rounded w-20" />
+      </div>
+    </div>
+  )
+}
+
+export default function ProjectGrid({
+  projects,
+  page,
+  totalPages,
+  totalItems,
+  onPageChange,
+  isLoading,
+}: ProjectGridProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 9 }).map((_, i) => (
+          <SkeletonCard key={i} />
+        ))}
+      </div>
+    )
+  }
+
+  if (projects.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center gap-3">
+        <Frown className="w-10 h-10 text-gray-300" />
+        <p className="text-gray-500 font-medium">No projects found</p>
+        <p className="text-sm text-gray-400">Try adjusting your search or filters</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-sm text-gray-500">
+        {totalItems.toLocaleString()} project{totalItems !== 1 ? 's' : ''} found
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {projects.map((project) => (
+          <ProjectCard key={project.id} project={project} />
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3 pt-2">
+          <button
+            type="button"
+            onClick={() => onPageChange(page - 1)}
+            disabled={page <= 1}
+            className="p-2 rounded-lg border border-gray-300 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50 transition-colors"
+            aria-label="Previous page"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+
+          <span className="text-sm text-gray-600">
+            Page {page} of {totalPages}
+          </span>
+
+          <button
+            type="button"
+            onClick={() => onPageChange(page + 1)}
+            disabled={page >= totalPages}
+            className="p-2 rounded-lg border border-gray-300 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50 transition-colors"
+            aria-label="Next page"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/explore/components/SearchBar.tsx
+++ b/src/features/explore/components/SearchBar.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useRef } from 'react'
+import { Search, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface SearchBarProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  className?: string
+}
+
+export default function SearchBar({
+  value,
+  onChange,
+  placeholder = 'Search projects by title, description, or keyword…',
+  className,
+}: SearchBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <div className={cn('relative flex items-center', className)}>
+      <Search className="absolute left-3 w-4 h-4 text-gray-400 pointer-events-none" />
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full pl-9 pr-9 py-2.5 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent bg-white placeholder:text-gray-400"
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => {
+            onChange('')
+            inputRef.current?.focus()
+          }}
+          className="absolute right-3 text-gray-400 hover:text-gray-600 transition-colors"
+          aria-label="Clear search"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/features/explore/hooks/useSearchProjects.ts
+++ b/src/features/explore/hooks/useSearchProjects.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+import { SearchProject } from '@think-storm/contracts'
+import { searchProjects } from '../api/projectsApi'
+
+export function useSearchProjects(params: SearchProject) {
+  return useQuery({
+    queryKey: ['projects', 'search', params],
+    queryFn: () => searchProjects(params),
+    staleTime: 30_000,
+  })
+}

--- a/src/features/explore/index.tsx
+++ b/src/features/explore/index.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { ProjectStatus, Goal } from '@think-storm/contracts'
+import { useSearchProjects } from './hooks/useSearchProjects'
+import SearchBar from './components/SearchBar'
+import FilterPanel from './components/FilterPanel'
+import ProjectGrid from './components/ProjectGrid'
+
+const PAGE_SIZE = 12
+
+export default function ExploreFeature() {
+  const [inputValue, setInputValue] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+  const [status, setStatus] = useState<ProjectStatus | ''>('')
+  const [goal, setGoal] = useState<Goal | ''>('')
+  const [page, setPage] = useState(1)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(inputValue)
+      setPage(1)
+    }, 400)
+    return () => clearTimeout(timer)
+  }, [inputValue])
+
+  const queryParams = {
+    ...(debouncedQuery ? { searchQuery: debouncedQuery } : {}),
+    ...(status ? { status } : {}),
+    ...(goal ? { goal } : {}),
+    page,
+    limit: PAGE_SIZE,
+  }
+
+  const { data, isLoading } = useSearchProjects(queryParams)
+
+  const handleReset = () => {
+    setInputValue('')
+    setDebouncedQuery('')
+    setStatus('')
+    setGoal('')
+    setPage(1)
+  }
+
+  const handleStatusChange = (newStatus: ProjectStatus | '') => {
+    setStatus(newStatus)
+    setPage(1)
+  }
+
+  const handleGoalChange = (newGoal: Goal | '') => {
+    setGoal(newGoal)
+    setPage(1)
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">Explore Projects</h1>
+          <p className="mt-1 text-gray-600">Discover and join projects from creators around the world</p>
+        </div>
+
+        <div className="mb-6 flex flex-col sm:flex-row gap-3">
+          <SearchBar
+            value={inputValue}
+            onChange={setInputValue}
+            className="flex-1"
+          />
+          <FilterPanel
+            status={status}
+            goal={goal}
+            onStatusChange={handleStatusChange}
+            onGoalChange={handleGoalChange}
+            onReset={handleReset}
+          />
+        </div>
+
+        <ProjectGrid
+          projects={data?.projects ?? []}
+          page={data?.page ?? page}
+          totalPages={data?.totalPages ?? 1}
+          totalItems={data?.totalItems ?? 0}
+          onPageChange={setPage}
+          isLoading={isLoading}
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- Add projectsApi with searchProjects() wired to GET /projects/search
- Add useSearchProjects TanStack Query hook with 30s stale time
- Add ProjectCard component with status/goal badges, labels, and metadata
- Add SearchBar with debounced input and clear button
- Add FilterPanel with status and goal dropdowns
- Add ProjectGrid with skeleton loading, empty state, and pagination
- Replace ExplorePage stub with fully functional ExploreFeature
- Add MY_PROJECTS route to constants/routes.ts

## Related Issue

- Put here the Task Id from github or clickup task by specifiyng which one you choose

## Description

- Write here a description of the feature or the bugfix that has been made

## Details

- [] List the details one by one
- []

## Reviewers

- You can tag here (@Elyoth) the reviewers for that pull request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Implemented a fully searchable Explore page for discovering projects with debounced real-time search
- Added project filtering by status and goals with a quick reset option
- Introduced paginated project grid view displaying comprehensive project information including titles, descriptions, labels, and metadata
- Updated application routes to support project details, profiles, and project-specific API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->